### PR TITLE
feat(chart): Support dynamic registries with pull secret and pull policy

### DIFF
--- a/charts/plumber/Chart.lock
+++ b/charts/plumber/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 25.3.9
+digest: sha256:b73bce4f620c0eb4c95400630198c7fbb2dcd542c682a924f0b52c7e611ae000
+generated: "2026-04-02T14:27:22.689377+02:00"

--- a/charts/plumber/Chart.yaml
+++ b/charts/plumber/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: plumber
 description: Helm chart for Plumber
 type: application
-version: "1.1.2"
-appVersion: "1.1.2"
+version: "1.2.0"
+appVersion: "1.2.0"
 home: https://github.com/getplumber/platform/
 maintainers:
   - name: devpro

--- a/charts/plumber/Chart.yaml
+++ b/charts/plumber/Chart.yaml
@@ -14,3 +14,10 @@ maintainers:
     email: thomas@getplumber.io
   - name: Totara-thib
     email: thibaud@getplumber.io
+  - name: Joseph94m
+    email: joseph.moukarzel@jmclarity.com
+dependencies:
+  - name: redis
+    version: "~25"
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.deploy

--- a/charts/plumber/templates/deployment.yaml
+++ b/charts/plumber/templates/deployment.yaml
@@ -118,6 +118,7 @@ spec:
               value: "{{ $.Values.redis.custom.user }}"
             - name: JOBS_REDIS_SET_NAMESPACES_TTL
               value: "30s"
+
             - name: GITLEAKS_PATH
               value: "/opt/gitleaks"
 
@@ -213,7 +214,7 @@ spec:
             name: {{ .configMapName | default "plumber-ca-certificates" }}
           {{- else }}
           emptyDir:
-            sizeLimit: 1Ki
+            sizeLimit: 1Mi
           {{- end }}
         {{- end }}
 

--- a/charts/plumber/templates/deployment.yaml
+++ b/charts/plumber/templates/deployment.yaml
@@ -35,11 +35,15 @@ spec:
         {{- end }}
     spec:
       automountServiceAccountToken: {{ .automountServiceAccountToken }}
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
       containers:
         - name: {{ .name }}
-          image: {{ .image }}:{{ .tag }}
-          imagePullPolicy: Always
+          image: {{ if $.Values.imageRegistry }}{{ $.Values.imageRegistry }}/{{ .imageName }}{{ else }}{{ .image }}{{ end }}:{{ .tag }}
+          imagePullPolicy: {{ .imagePullPolicy | default "Always" }}
           {{- if .command }}
           command: {{ .command }}
           {{- end }}

--- a/charts/plumber/tests/deployment_test.yaml
+++ b/charts/plumber/tests/deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
           content:
             name: ca-certificates
             emptyDir:
-              sizeLimit: 1Ki
+              sizeLimit: 1Mi
 
   - it: Deployments should bind to an external secret if .existingSecret is set
     set:

--- a/charts/plumber/values.yaml
+++ b/charts/plumber/values.yaml
@@ -4,11 +4,24 @@ additionalAnnotations: {}
 # -- Additional labels applied to all resources.
 additionalLabels: {}
 
+# -- Global image registry override. When set, images are pulled as <imageRegistry>/<imageName>:<tag>.
+# Leave empty to use the full path from each component's `image` field (default behavior).
+imageRegistry: ""
+
+# -- Global image pull secrets for pulling from private registries.
+imagePullSecrets: []
+  # - name: my-registry-secret
+
 front:
   enabled: true
   type: frontend
   name: plumber-front
+  # -- Full image path (used when imageRegistry is empty).
   image: docker.io/getplumber/frontend
+  # -- Image name without registry prefix (used when imageRegistry is set).
+  imageName: getplumber/frontend
+  # -- Image pull policy for the container.
+  imagePullPolicy: Always
   tag: v2.34.4
   replicaCount: 1
   revisionHistoryLimit: 5
@@ -67,7 +80,12 @@ backend:
   enabled: true
   type: backend
   name: plumber-backend
+  # -- Full image path (used when imageRegistry is empty).
   image: docker.io/getplumber/backend
+  # -- Image name without registry prefix (used when imageRegistry is set).
+  imageName: getplumber/backend
+  # -- Image pull policy for the container.
+  imagePullPolicy: Always
   tag: v2.37.1
   replicaCount: 1
   revisionHistoryLimit: 5
@@ -149,7 +167,12 @@ worker:
   enabled: true
   type: backend
   name: plumber-worker
+  # -- Full image path (used when imageRegistry is empty).
   image: docker.io/getplumber/backend
+  # -- Image name without registry prefix (used when imageRegistry is set).
+  imageName: getplumber/backend
+  # -- Image pull policy for the container.
+  imagePullPolicy: Always
   tag: v2.37.1
   replicaCount: 5
   revisionHistoryLimit: 5

--- a/charts/plumber/values.yaml
+++ b/charts/plumber/values.yaml
@@ -260,8 +260,36 @@ postgresql:
       #     adminPasswordKey: "password"
       #     userPasswordKey: "password"
 
-# External Redis
+# Redis
 redis:
+  # -- Set to true to deploy a Redis instance as part of this chart (via bitnami/redis sub-chart).
+  # When false (default), Redis is treated as an external dependency and you must provide connection details below.
+  deploy: false
+
+  # -- Redis architecture when deployed by this chart. Options: "standalone" or "replication".
+  # Keep Standalone for now because we do not support replication yet.
+  architecture: standalone
+
+  # Image configuration (only used when deploy is true).
+  # Override these to pull from a private registry or mirror.
+  # When using a non-bitnami registry, you must also set global.security.allowInsecureImages to true.
+  image:
+  #   registry: my-private-registry.example.com
+  #   repository: bitnami/redis
+  #   tag: "latest"
+    digest: "sha256:98cf67395e80506c7bc21b889107980365558ef30d59059ac6d76aab2678bf7e"
+  #   pullPolicy: IfNotPresent
+  #   pullSecrets:
+  #     - my-registry-secret
+
+  # Persistence for deployed Redis (only used when deploy is true).
+  # Disabled by default — Redis is used as a cache/queue, data loss on restart is acceptable.
+  master:
+    persistence:
+      enabled: false
+
+  # Connection details for the Redis instance (used whether deployed by this chart or external).
+  # When deploy is true and custom.host is empty, the host defaults to the sub-chart's service (<release>-redis-master).
   custom:
     host: ""
     user: "default"


### PR DESCRIPTION
Closes #20 #21 #22

Edit: also added commit to support deploying a redis. Partially Closing #24  but should be good enough for now.