### PR TITLE
Add built-in PostgreSQL & fix Redis security context

### DIFF
--- a/charts/plumber/Chart.yaml
+++ b/charts/plumber/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: plumber
 description: Helm chart for Plumber
 type: application
-version: "1.3.4"
-appVersion: "1.3.4"
+version: "1.3.5"
+appVersion: "1.3.5"
 home: https://github.com/getplumber/platform/
 maintainers:
   - name: devpro

--- a/charts/plumber/templates/_helpers.tpl
+++ b/charts/plumber/templates/_helpers.tpl
@@ -10,3 +10,16 @@ Produces: [registry/]repository:tag[@digest]
 {{- $base := ternary (printf "%s/%s" $reg $repo) $repo (ne $reg "") -}}
 {{- ternary (printf "%s:%s@%s" $base $tag $dig) (printf "%s:%s" $base $tag) (ne $dig "") -}}
 {{- end }}
+
+{{/*
+Build the PostgreSQL image reference from values.
+Produces: [registry/]repository:tag[@digest]
+*/}}
+{{- define "plumber.postgresImage" -}}
+{{- $reg  := .Values.postgresql.image.registry -}}
+{{- $repo := .Values.postgresql.image.repository -}}
+{{- $tag  := .Values.postgresql.image.tag -}}
+{{- $dig  := .Values.postgresql.image.digest -}}
+{{- $base := ternary (printf "%s/%s" $reg $repo) $repo (ne $reg "") -}}
+{{- ternary (printf "%s:%s@%s" $base $tag $dig) (printf "%s:%s" $base $tag) (ne $dig "") -}}
+{{- end }}

--- a/charts/plumber/templates/deployment.yaml
+++ b/charts/plumber/templates/deployment.yaml
@@ -40,6 +40,34 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
+      {{- if and (eq .type "backend") $.Values.postgresql.deploy }}
+      initContainers:
+        - name: wait-for-db
+          image: {{ include "plumber.postgresImage" $ }}
+          imagePullPolicy: {{ $.Values.postgresql.image.pullPolicy | default "IfNotPresent" }}
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER"; do
+                echo "Waiting for PostgreSQL at $DB_HOST:$DB_PORT..."
+                sleep 3
+              done
+          env:
+            - name: DB_HOST
+              value: "{{ default (printf "%s-%s" $.Release.Name "postgresql") $.Values.postgresql.custom.host }}"
+            - name: DB_PORT
+              value: "{{ $.Values.postgresql.custom.port }}"
+            - name: DB_USER
+              value: "{{ $.Values.postgresql.global.postgresql.auth.username }}"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+      {{- end }}
       containers:
         - name: {{ .name }}
           image: {{ if $.Values.imageRegistry }}{{ $.Values.imageRegistry }}/{{ .imageName }}{{ else }}{{ .image }}{{ end }}:{{ .tag }}

--- a/charts/plumber/templates/redis-deployment.yaml
+++ b/charts/plumber/templates/redis-deployment.yaml
@@ -69,7 +69,8 @@ spec:
               port: redis
             initialDelaySeconds: 5
             periodSeconds: 10
-          resources: {}
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
           {{- with .Values.redis.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/charts/plumber/templates/statefulset-psql.yaml
+++ b/charts/plumber/templates/statefulset-psql.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.postgresql.deploy }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-postgresql" .Release.Name }}
+  labels:
+    app: {{ printf "%s-postgresql" .Release.Name }}
+    app.kubernetes.io/name: {{ printf "%s-postgresql" .Release.Name }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  clusterIP: None
+  selector:
+    app: {{ printf "%s-postgresql" .Release.Name }}
+    app.kubernetes.io/name: {{ printf "%s-postgresql" .Release.Name }}
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ printf "%s-postgresql" .Release.Name }}
+  labels:
+    app: {{ printf "%s-postgresql" .Release.Name }}
+    app.kubernetes.io/name: {{ printf "%s-postgresql" .Release.Name }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  replicas: 1
+  serviceName: {{ printf "%s-postgresql" .Release.Name }}
+  selector:
+    matchLabels:
+      app: {{ printf "%s-postgresql" .Release.Name }}
+      app.kubernetes.io/name: {{ printf "%s-postgresql" .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ printf "%s-postgresql" .Release.Name }}
+        app.kubernetes.io/name: {{ printf "%s-postgresql" .Release.Name }}
+        {{- range $key, $val := .Values.additionalLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+    spec:
+      automountServiceAccountToken: {{ .Values.postgresql.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgresql
+          image: {{ include "plumber.postgresImage" . }}
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.custom.dbName | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.global.postgresql.auth.username | quote }}
+            - name: POSTGRES_PASSWORD
+              {{- if .Values.postgresql.global.postgresql.auth.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.global.postgresql.auth.existingSecret | quote }}
+                  key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.adminPasswordKey | quote }}
+              {{- else }}
+              value: {{ .Values.postgresql.global.postgresql.auth.postgresPassword | quote }}
+              {{- end }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "$(POSTGRES_USER)", "-d", "$(POSTGRES_DB)"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "$(POSTGRES_USER)", "-d", "$(POSTGRES_DB)"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          {{- with .Values.postgresql.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [{{ .Values.postgresql.persistence.accessMode | quote }}]
+        {{- with .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size | quote }}
+{{- end }}

--- a/charts/plumber/values.yaml
+++ b/charts/plumber/values.yaml
@@ -235,8 +235,61 @@ customCertificateAuthority:
   #     (SNIPPED FOR BREVITY)
   #     -----END CERTIFICATE-----
 
-# External PostgreSQL
+# PostgreSQL
 postgresql:
+  # -- Set to true to deploy a PostgreSQL instance as part of this chart.
+  # When false, PostgreSQL is treated as an external dependency — provide connection details in custom below.
+  deploy: false
+
+  # Image configuration for the bundled PostgreSQL instance (only used when deploy is true).
+  image:
+    # -- Optional registry prefix (e.g. my-private-registry.example.com).
+    # When set, the image is pulled as <registry>/<repository>:<tag>.
+    # Leave empty to use repository as-is.
+    registry: ""
+    # -- Image repository. Override to pull from a mirror or private registry.
+    repository: postgres
+    # -- Image tag.
+    tag: "18"
+    # -- Optional content-addressable digest (sha256:...).
+    # When set, pins the exact image version regardless of tag.
+    digest: ""
+    # -- Pull policy for the PostgreSQL image.
+    pullPolicy: IfNotPresent
+
+  # -- Security context for the PostgreSQL container.
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
+    privileged: false
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    seccompProfile:
+      type: RuntimeDefault
+
+  # -- Security context for the PostgreSQL pod.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    fsGroup: 999
+    seccompProfile:
+      type: RuntimeDefault
+
+  # -- Persistence configuration for PostgreSQL data (only used when deploy is true).
+  persistence:
+    size: "10Gi"
+    storageClass: ""
+    accessMode: ReadWriteOnce
+
+  resources: {}
+
+  automountServiceAccountToken: true
+
+  # Connection details for the PostgreSQL instance (used whether deployed by this chart or external).
+  # When deploy is true and custom.host is empty, the host defaults to <release>-postgresql.
   custom:
     host: ""
     dbName: "plumber"
@@ -302,6 +355,8 @@ redis:
     fsGroup: 999
     seccompProfile:
       type: RuntimeDefault
+
+  resources: {}
 
   # Connection details for the Redis instance (used whether deployed by this chart or external).
   # When deploy is true and custom.host is empty, the host defaults to <release>-redis-master.


### PR DESCRIPTION
Salut,

Je propose l'ajout d'un PostgreSQL StatefulSet built-in.

**PostgreSQL**
Ajout de statefulset-psql.yaml : déploie un StatefulSet PostgreSQL + Service + PVC lorsque postgresql.deploy: true. Utile pour les environnements sans base externe. Désactivé par défaut, donc aucun impact sur les installations existantes.

**Redis**
Templating des resource requests/limits, je pense qu'il s'agissait d'un oubli. Sans ça, les policies d'admission qui forcent des resource constraints rejettent le pod.

**Backend**
Ajout d'un init container pour éviter la race condition quand PostgreSQL n'est pas encore prêt, ce qui évite les CrashLoopBackoffs au démarrage.

Merci pour votre travail sur Plumber !

-- EN --

Hi,

I'd like to propose a PR adding a built-in PostgreSQL StatefulSet.

**PostgreSQL**

Added statefulset-psql.yaml: deploys a PostgreSQL StatefulSet + Service + PVC when postgresql.deploy: true. Useful for environments without an external database. Disabled by default, so no impact on existing installations.

**Redis**
Templated resources requests/limits, I believe this was an oversight. Without it, admission policies that enforce resource constraints will reject the pod.

**Backend**
Added an init container to avoid the race condition when PostgreSQL isn't ready yet, preventing CrashLoopBackoffs on startup.

Thanks for your work on Plumber!