### PR TITLE
ci: scan repo with Plumber Score action

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,28 @@
+name: Plumber
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  plumber:
+    name: CI/CD compliance scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+      - name: Run Plumber
+        uses: getplumber/plumber@303ade500dee048f997bba7934dd54628bf08a3a # v0.3.74


### PR DESCRIPTION
## What

Adds `.github/workflows/plumber.yml` so this repo runs the official **Plumber Score** GitHub Action on itself (dogfooding). Triggers on push/PR to `main` and `workflow_dispatch`.

## Why

The repo already ships a `.plumber.yaml` config but nothing was actually running Plumber in CI. This wires up the latest action release.

## Details

- Uses `getplumber/plumber@303ade500dee048f997bba7934dd54628bf08a3a` (**v0.3.74**), the current Marketplace "Plumber Score" action.
- **Pinned by commit SHA** with a version comment, satisfying the repo's own `actionsMustBePinnedByCommitSha` policy in `.plumber.yaml` (only `actions`/`github` owners are exempt).
- `permissions: security-events: write` so the action can upload its SARIF to GitHub Code Scanning.
- Auto-detects the existing `.plumber.yaml` and uses the default `threshold: 100`.

## Optional follow-ups

- Enable the public A–E score badge via `score-push: true` + `id-token: write` (off by default).
- Add Dependabot with `version-update-strategy: sha-and-version` to keep the pin fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)